### PR TITLE
Adds my RockBand Midi Adapter

### DIFF
--- a/Config/AdapterConfig.h
+++ b/Config/AdapterConfig.h
@@ -17,4 +17,4 @@
 #define ANNOUNCE_INTERVAL_MS 2000
 
 // #define SERIAL_DEBUG Serial1
-// #define CUSTOM_MIDI_MAP "Config/MyCustomMidiMap.tbl"
+#define CUSTOM_MIDI_MAP "Config/RBMidiMapping.tbl"

--- a/Config/RBMidiMapping.tbl
+++ b/Config/RBMidiMapping.tbl
@@ -1,0 +1,38 @@
+#ifndef MIDI_MAP
+#pragma error "MidiMapping.tbl should only be included after MIDI_MAP has been defined"
+#endif
+// Kick
+MIDI_MAP(36, OUT_KICK)
+MIDI_MAP(44, OUT_KICK) //  Hi-Hat Pedal
+
+// Snare (red pad)
+MIDI_MAP(38, OUT_PAD_RED)
+MIDI_MAP(40, OUT_PAD_RED) // Rim
+
+// Tom 3 (green pad)
+MIDI_MAP(43, OUT_PAD_GREEN)
+MIDI_MAP(58, OUT_PAD_GREEN) // Rim
+
+// Tom 2 (blue pad)
+MIDI_MAP(45, OUT_PAD_BLUE)
+MIDI_MAP(47, OUT_PAD_BLUE) // Rim
+
+// Tom 1 (yellow pad)
+MIDI_MAP(48, OUT_PAD_YELLOW)
+MIDI_MAP(50, OUT_PAD_YELLOW) // Rim
+
+// Hi-Hat (yellow cymbal)
+MIDI_MAP(46, OUT_CYM_YELLOW) // Hi-Hat Open
+MIDI_MAP(22, OUT_CYM_YELLOW) // Hi-Hat Open (alt)
+MIDI_MAP(23, OUT_CYM_YELLOW) // Hi-Hat Half-Open
+MIDI_MAP(42, OUT_CYM_YELLOW) // Hi-Hat Closed
+
+// Technically the Crash should be Green and Ride be Blue
+// but for sake of simplicity with Rock Band 4, I inverted
+// them to match the toy drums.
+
+// Crash 1 (blue cymbal)
+MIDI_MAP(49, OUT_CYM_BLUE)
+
+// Ride (green cymbal)
+MIDI_MAP(51, OUT_CYM_GREEN)


### PR DESCRIPTION
Adding and enabling by default my MIDI mapping configuration for RB4. This configuration has been tested with the Alesis Nitro and Alesis Turbo modules.